### PR TITLE
Fix import paths

### DIFF
--- a/apps/web/src/app/api/update-subscription.ts
+++ b/apps/web/src/app/api/update-subscription.ts
@@ -1,9 +1,9 @@
-import { savePushSubscription } from "@/lib/webpush/savePushSubscription";
+import { saveSubscription } from "@/utils/push";
 import { NextResponse } from "next/server";
 
 // app/subscription/route.ts
 export async function POST(req: Request) {
   const { newSubscription } = await req.json();
-  await savePushSubscription(newSubscription);
+  await saveSubscription(newSubscription);
   return NextResponse.json({ success: true });
 }

--- a/apps/web/src/components/ui/NotificationRequester.tsx
+++ b/apps/web/src/components/ui/NotificationRequester.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 // Импортируем серверные экшны
-import { getVapidPublicKey } from "@/lib/webpush/getVapidPublicKey";
-import { savePushSubscription } from "@/lib/webpush/savePushSubscription";
+import { getVapidPublicKey, saveSubscription } from "@/utils/push";
 
 // Утилита для конвертации VAPID-ключа из base64 в Uint8Array
 function urlBase64ToUint8Array(base64String: string) {
@@ -56,7 +55,7 @@ export default function NotificationRequester() {
           "🔹 Before savePushSubscription, endpoint:",
           subscriptionJSON.endpoint
         );
-        await savePushSubscription(
+        await saveSubscription(
           subscriptionJSON as {
             endpoint: string;
             keys: { p256dh: string; auth: string };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -30,9 +30,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    "../../packages/webpush/src/getVapidPublicKey.ts",
     "../../packages/webpush/src/db.ts",
-    "../../packages/webpush/src/webpush.ts",
+    "../../packages/webpush/src/index.ts",
     "src/utils/push.ts",
     "src/utils/getCurrentUserId.ts"
   ],

--- a/packages/webpush/src/db.ts
+++ b/packages/webpush/src/db.ts
@@ -1,6 +1,6 @@
 "use server";
 import { prisma } from "@prisma";
-import { getCurrentUserId } from "../../../apps/web/src/utils/getCurrentUserId.js";
+import { getCurrentUserId } from "@web/utils/getCurrentUserId";
 
 export type PushSubscriptionJSON = {
   endpoint: string;

--- a/packages/worker/src/push-worker.ts
+++ b/packages/worker/src/push-worker.ts
@@ -3,8 +3,8 @@ console.log("🟢 [Worker] Starting push-worker process...");
 import "dotenv/config";
 import { Worker, Job } from "bullmq";
 import { prisma } from "@prisma";
-import webpush from "../../webpush/src/webpush.js";
-import { connection } from "../redis.js";
+import webpush from "@gafus/webpush";
+import { connection } from "@queues/redis";
 import type { PushSubscription } from "web-push";
 
 interface SendStepNotificationPayload {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,8 @@
       "@queues/*": ["packages/queues/src/*"],
       "@gafus/webpush": ["packages/webpush/src/index.ts"],
       "@gafus/webpush/db": ["packages/webpush/src/db.ts"],
-      "@gafus/types": ["packages/types/src"]
+      "@gafus/types": ["packages/types/src"],
+      "@web/*": ["apps/web/src/*"]
     },
 
     "typeRoots": ["./node_modules/@types", "packages/types/src"]


### PR DESCRIPTION
## Summary
- fix worker imports to use package aliases
- use utils/push actions in NotificationRequester and update-subscription
- update Next.js tsconfig includes
- add global alias for web app utilities
- update webpush DB import to use new alias

## Testing
- `npm run typecheck` *(fails: turbo not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e96083f6c8326beb54b030fa28957