### PR TITLE
Fix tsconfig alias handling

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -14,13 +14,7 @@
     "noEmit": true,
     "incremental": true,
 
-    /* Пути и алиасы */
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"],
-      "@prisma": ["../../packages/prisma/src/index.ts"],
-      "@queues/*": ["../../packages/queues/src/*"]
-    },
+    /* Пути и алиасы наследуются из корневого tsconfig */
 
     /* Типы */
     "typeRoots": ["./types", "../../packages/types/src", "../../node_modules/@types"]

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDeclarationOnly": true, // не генерировать JS
     "outDir": "dist", // декларации будут в dist
     "rootDir": "src", // исходники в src
-    "baseUrl": ".", // для paths внутри пакета
+    /* пути и алиасы наследуются из корневого tsconfig */
     "skipLibCheck": true // ускоряет сборку
   },
   "include": ["src"]

--- a/packages/webpush/tsconfig.json
+++ b/packages/webpush/tsconfig.json
@@ -5,11 +5,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
 
-    "baseUrl": ".",
-    "paths": {
-      "@prisma": ["../prisma/src/index.ts"],
-      "@web/*": ["../../apps/web/src/*"]
-    },
+    /* пути и алиасы наследуются из корневого tsconfig */
 
     "outDir": "dist",
     "noEmit": false

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "baseUrl": ".",
-    "paths": {
-      "@shared/*": ["../shared/src/*"]
-    },
+    /* пути и алиасы наследуются из корневого tsconfig */
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,7 +21,8 @@
       "@gafus/webpush": ["packages/webpush/src/index.ts"],
       "@gafus/webpush/db": ["packages/webpush/src/db.ts"],
       "@gafus/types": ["packages/types/src"],
-      "@web/*": ["apps/web/src/*"]
+      "@web/*": ["apps/web/src/*"],
+      "@/*": ["apps/web/src/*"]
     },
 
     "typeRoots": ["./node_modules/@types", "packages/types/src"]


### PR DESCRIPTION
## Summary
- centralize path aliases in `tsconfig.base.json`
- clean up project-level `tsconfig.json` files to rely on base config

## Testing
- `npx tsc -p packages/webpush/tsconfig.json --noEmit` *(fails: Cannot find module '@prisma/client' and other types)*

------
https://chatgpt.com/codex/tasks/task_e_685ea8883c208326aed99134de601026